### PR TITLE
fix: Caddy persistence to use share name not storage account name when supplied as a variable

### DIFF
--- a/modules/caddy-automatic-https/locals.tf
+++ b/modules/caddy-automatic-https/locals.tf
@@ -36,7 +36,7 @@ locals {
       ? module.caddy_persistence_storage_account.storage_primary_access_key
       : var.caddy_persistence_storage_account.key
     )
-    share_name = var.caddy_persistence_storage_account == null ? "caddy" : var.caddy_persistence_storage_account.name
+    share_name = var.caddy_persistence_storage_account == null ? "caddy" : var.caddy_persistence_storage_account.share_name
   }
 
   caddyfile_base64_encoded = coalesce(


### PR DESCRIPTION
When supplying the storage account details for the Caddy container in var.caddy_persistence_storage_account, the local for share_name is using the storage account name, not the supplied share name.